### PR TITLE
[srt]加入livestream兩種protocol類型(RTMP、SRT)

### DIFF
--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
@@ -134,17 +134,17 @@ class VideoMediaCodecEncoder(
                  * When surface is called twice without the stopStream(). When configure() is
                  * called twice for example,
                  */
-                executor.submit {
-                    if (eglSurface != null) {
-                        detachSurfaceTexture()
-                    }
-                    synchronized(this) {
-                        value?.let {
-                            initOrUpdateSurfaceTexture(it)
-                        }
-                    }
-
-                }.get() // Wait till executor returns
+//                executor.submit {
+//                    if (eglSurface != null) {
+//                        detachSurfaceTexture()
+//                    }
+//                    synchronized(this) {
+//                        value?.let {
+//                            initOrUpdateSurfaceTexture(it)
+//                        }
+//                    }
+//
+//                }.get() // Wait till executor returns
                 field = value
             }
 

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/IVideoCapture.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/IVideoCapture.kt
@@ -24,4 +24,10 @@ interface IVideoCapture : IFrameCapture<VideoConfig>, ISurfaceCapture {
      * buffer producer (see [IFrameCapture]).
      */
     val hasSurface: Boolean
+
+    /**
+     * Custom encoder lets us using encoded data from filter,
+     * instead of surface data from camera.
+     * */
+    val useCustomRecorder: Boolean
 }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
@@ -34,7 +34,7 @@ class CameraCapture(
 ) : IVideoCapture {
     var previewSurface: Surface? = null
     override var encoderSurface: Surface? = null
-    var cameraId: String = "0"
+    var cameraId: String = "1"
         get() = cameraController.cameraId ?: field
         @RequiresPermission(Manifest.permission.CAMERA)
         set(value) {
@@ -93,21 +93,21 @@ class CameraCapture(
         require(encoderSurface != null) { "encoder surface must not be null" }
 
     override fun startStream() {
-        checkStream()
+//        checkStream()
 
         cameraController.muteVibrationAndSound()
-        cameraController.addTarget(encoderSurface!!)
+//        cameraController.addTarget(encoderSurface!!)
         isStreaming = true
     }
 
     override fun stopStream() {
         if (isStreaming) {
-            checkStream()
+//            checkStream()
 
             cameraController.unmuteVibrationAndSound()
 
             isStreaming = false
-            cameraController.removeTarget(encoderSurface!!)
+//            cameraController.removeTarget(encoderSurface!!)
         }
     }
 

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
@@ -17,6 +17,7 @@ package io.github.thibaultbee.streampack.internal.sources.camera
 
 import android.Manifest
 import android.content.Context
+import android.hardware.Camera.CameraInfo.CAMERA_FACING_FRONT
 import android.view.Surface
 import androidx.annotation.RequiresPermission
 import io.github.thibaultbee.streampack.data.VideoConfig
@@ -34,7 +35,7 @@ class CameraCapture(
 ) : IVideoCapture {
     var previewSurface: Surface? = null
     override var encoderSurface: Surface? = null
-    var cameraId: String = "1"
+    var cameraId: String = "$CAMERA_FACING_FRONT"
         get() = cameraController.cameraId ?: field
         @RequiresPermission(Manifest.permission.CAMERA)
         set(value) {

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraCapture.kt
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer
 
 class CameraCapture(
     private val context: Context,
-    logger: ILogger
+    val logger: ILogger,
 ) : IVideoCapture {
     var previewSurface: Surface? = null
     override var encoderSurface: Surface? = null
@@ -56,6 +56,7 @@ class CameraCapture(
 
     override val timestampOffset = CameraHelper.getTimeOffsetToMonoClock(context, cameraId)
     override val hasSurface = true
+    override val useCustomRecorder = true
     override fun getFrame(buffer: ByteBuffer): Frame {
         throw UnsupportedOperationException("Camera expects to run in Surface mode")
     }
@@ -93,21 +94,24 @@ class CameraCapture(
         require(encoderSurface != null) { "encoder surface must not be null" }
 
     override fun startStream() {
-//        checkStream()
+        if (!useCustomRecorder) {
+            checkStream()
+            cameraController.addTarget(encoderSurface!!)
+        }
 
         cameraController.muteVibrationAndSound()
-//        cameraController.addTarget(encoderSurface!!)
         isStreaming = true
     }
 
     override fun stopStream() {
         if (isStreaming) {
-//            checkStream()
+            if (!useCustomRecorder) {
+                checkStream()
+                cameraController.removeTarget(encoderSurface!!)
+            }
 
             cameraController.unmuteVibrationAndSound()
-
             isStreaming = false
-//            cameraController.removeTarget(encoderSurface!!)
         }
     }
 

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/screen/ScreenCapture.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/screen/ScreenCapture.kt
@@ -39,6 +39,7 @@ class ScreenCapture(
     override var encoderSurface: Surface? = null
     override val timestampOffset = 0L
     override val hasSurface = true
+    override val useCustomRecorder = true
     override fun getFrame(buffer: ByteBuffer): Frame {
         throw UnsupportedOperationException("Screen source expects to run in Surface mode")
     }

--- a/core/src/main/java/io/github/thibaultbee/streampack/listeners/OnConnectionListener.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/listeners/OnConnectionListener.kt
@@ -38,4 +38,14 @@ interface OnConnectionListener {
      * Called when a connection just succeeded.
      */
     fun onSuccess()
+
+    /**
+     * Called when disconnecting the connection.
+     */
+    fun onDisconnect()
+
+    /**
+     * Called when updating the bitrate
+     */
+    fun onNewBitrate(bitrate: Long)
 }

--- a/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
@@ -79,6 +79,9 @@ abstract class BaseStreamer(
     protected var videoConfig: VideoConfig? = null
     private var audioConfig: AudioConfig? = null
 
+    var droppedAudioFrames: Long = 0
+    var droppedVideoFrames: Long = 0
+
     // Only handle stream error (error on muxer, endpoint,...)
     /**
      * Internal usage only
@@ -99,6 +102,7 @@ abstract class BaseStreamer(
                 try {
                     this@BaseStreamer.muxer.encode(frame, it)
                 } catch (e: Exception) {
+                    droppedAudioFrames++
                     throw StreamPackError(e)
                 }
             }
@@ -121,6 +125,7 @@ abstract class BaseStreamer(
 //                    }
                     this@BaseStreamer.muxer.encode(frame, it)
                 } catch (e: Exception) {
+                    droppedVideoFrames++
                     // Send exception to encoder
                     throw StreamPackError(e)
                 }
@@ -344,6 +349,7 @@ abstract class BaseStreamer(
      * @see [stopStream]
      */
     private fun resetAudio() {
+        droppedAudioFrames = 0
         audioEncoder?.release()
 
         // Reconfigure
@@ -358,6 +364,7 @@ abstract class BaseStreamer(
      * @see [stopStream]
      */
     private fun resetVideo() {
+        droppedVideoFrames = 0
         videoEncoder?.release()
 
         // And restart...

--- a/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
@@ -166,7 +166,8 @@ abstract class BaseStreamer(
             context,
             videoCapture.hasSurface,
             manageVideoOrientation,
-            logger
+            logger,
+            videoCapture.useCustomRecorder,
         )
     } else {
         null

--- a/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
@@ -113,12 +113,12 @@ abstract class BaseStreamer(
         override fun onOutputFrame(frame: Frame) {
             videoTsStreamId?.let {
                 try {
-                    frame.pts += videoCapture!!.timestampOffset
-                    frame.dts = if (frame.dts != null) {
-                        frame.dts!! + videoCapture.timestampOffset
-                    } else {
-                        null
-                    }
+//                    frame.pts += videoCapture!!.timestampOffset
+//                    frame.dts = if (frame.dts != null) {
+//                        frame.dts!! + videoCapture.timestampOffset
+//                    } else {
+//                        null
+//                    }
                     this@BaseStreamer.muxer.encode(frame, it)
                 } catch (e: Exception) {
                     // Send exception to encoder

--- a/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/streamers/bases/BaseStreamer.kt
@@ -159,7 +159,7 @@ abstract class BaseStreamer(
     } else {
         null
     }
-    protected var videoEncoder = if (videoCapture != null) {
+    var videoEncoder = if (videoCapture != null) {
         VideoMediaCodecEncoder(
             videoEncoderListener,
             onInternalErrorListener,

--- a/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/internal/endpoints/SrtProducer.kt
+++ b/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/internal/endpoints/SrtProducer.kt
@@ -120,6 +120,7 @@ class SrtProducer(
     override fun disconnect() {
         socket.close()
         socket = Socket()
+        onConnectionListener?.onDisconnect()
     }
 
     override fun write(packet: Packet) {

--- a/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/streamers/CameraSrtLiveStreamer.kt
+++ b/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/streamers/CameraSrtLiveStreamer.kt
@@ -82,6 +82,7 @@ class CameraSrtLiveStreamer(
     private val scheduler = Scheduler(500) {
         bitrateRegulator?.update(srtProducer.stats, settings.video.bitrate, settings.audio.bitrate)
             ?: throw UnsupportedOperationException("Scheduler runs but no bitrate regulator set")
+        onConnectionListener?.onNewBitrate(settings.video.bitrate as Long)
     }
 
     private val srtProducer = endpoint as SrtProducer

--- a/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/streamers/CameraSrtLiveStreamer.kt
+++ b/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/streamers/CameraSrtLiveStreamer.kt
@@ -82,7 +82,7 @@ class CameraSrtLiveStreamer(
     private val scheduler = Scheduler(500) {
         bitrateRegulator?.update(srtProducer.stats, settings.video.bitrate, settings.audio.bitrate)
             ?: throw UnsupportedOperationException("Scheduler runs but no bitrate regulator set")
-        onConnectionListener?.onNewBitrate(settings.video.bitrate as Long)
+        onConnectionListener?.onNewBitrate(settings.video.bitrate.toLong())
     }
 
     private val srtProducer = endpoint as SrtProducer


### PR DESCRIPTION
1. [VideoMediaCodecEncoder.kt](https://github.com/swaglive/StreamPack/pull/2/files#diff-14ef3d24092e60ee74c8df3dd0bae2e5e4649d6e9ee7f9396b23cc60209074a7)
使用濾鏡後的surfacetexture，因此註解掉StreamPack的surfacetexture

2. [CameraCapture.kt](https://github.com/swaglive/StreamPack/pull/2/files#diff-7e69fc2f53463494f6db6656bf29e501f17ef0ae3ed3bfeeb620c72ea3d6f8c4)
使用濾鏡後的swapbuffer的資料，因此註解掉不使用camera2傳遞target surface的資料