### PR TITLE
Feature/packet drop mechanism

### DIFF
--- a/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/internal/endpoints/SrtProducer.kt
+++ b/extensions/srt/src/main/java/io/github/thibaultbee/streampack/ext/srt/internal/endpoints/SrtProducer.kt
@@ -145,6 +145,13 @@ class SrtProducer(
             }
 
         try {
+            if (msgCtrl.boundary != Boundary.SOLO && packet.ts <= socket.connectionTime) {
+                /**
+                 * prevent meet `Wrong source time was provided. Sending is rejected.` exception
+                 * while sending socket packet
+                 * */
+                return
+            }
             socket.send(packet.buffer, msgCtrl)
         } catch (e: Exception) {
             isOnError = true


### PR DESCRIPTION
加上封包過濾機制，如果不是solo packet，timestamp又小於socket connect的話，會drop掉該封包，以免遇到socket.send的exception 

###
https://github.com/Haivision/srt/blob/v1.5.1/srtcore/core.cpp

        if (w_mctrl.srctime && w_mctrl.srctime < count_microseconds(m_stats.tsStartTime.time_since_epoch()))
        {
            LOGC(aslog.Error,
                log << "Wrong source time was provided. Sending is rejected.");
            throw CUDTException(MJ_NOTSUP, MN_INVALMSGAPI);
        }
###

base on `https://github.com/swaglive/StreamPack/pull/2`