### PR TITLE
[Bug] 修正PES packetize時的錯誤

### DIFF
--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/packets/PesHeader.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/packets/PesHeader.kt
@@ -72,9 +72,8 @@ class PesHeader(
         buffer.putShort(0) // start code is 0x000001
         buffer.put(1)
         buffer.put(streamId)
-        if (pesPacketLength > 0xFFFF)
-            pesPacketLength = 0
-        buffer.putShort(pesPacketLength)
+        // PES packet length, use 0 to let decoder calculate payload length by unit_start
+        buffer.putShort(0)
         // Optional
         buffer.put(
             ((0b10 shl 6)

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/packets/TS.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/packets/TS.kt
@@ -87,11 +87,6 @@ open class TS(
                 adaptationFieldIndicator = false
             }
 
-            // Then specific stream header. Mainly for PES header.
-            specificHeader?.let {
-                buffer.put(it)
-            }
-
             // Fill packet with correct size of payload
             payload?.let {
                 if (stuffingForLastPacket) {
@@ -101,6 +96,7 @@ open class TS(
                         val currentPacketFirstPosition =
                             buffer.position() / PACKET_SIZE * PACKET_SIZE
                         byte = buffer[currentPacketFirstPosition + 3].toInt()
+                        // Update adaptation field indicator to enable
                         byte = byte or (1 shl 5)
                         buffer.position(currentPacketFirstPosition + 3)
                         buffer.put(byte.toByte())
@@ -114,6 +110,11 @@ open class TS(
                             }
                         }
                     }
+                }
+
+                // Then specific stream header. Mainly for PES header.
+                specificHeader?.let { header ->
+                    buffer.put(header)
                 }
 
                 it.limit(it.position() + buffer.remaining().coerceAtMost(it.remaining()))


### PR DESCRIPTION
- [x] fix incorrect payload length. Set payload length packet to 0, let decoder calculate by unit_start bit.
- [x] PES header should be after stuffing 0xff.